### PR TITLE
Add missing DateTimeNormalizer

### DIFF
--- a/src/Service/ApiRequest.php
+++ b/src/Service/ApiRequest.php
@@ -15,6 +15,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
@@ -36,6 +37,7 @@ abstract class ApiRequest
         $encoder = [new JsonEncoder()];
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = [
+            new DateTimeNormalizer(),
             new BackedEnumNormalizer(),
             new ArrayDenormalizer(),
             new ObjectNormalizer(null, null, null, $extractor),


### PR DESCRIPTION
The `DateTimeNormalizer` is currently missing, which leads to an error when trying to create a CheckoutIntent with a payer containing a birthDate.