### PR TITLE
Introduce payment service

### DIFF
--- a/src/HelloassoClient.php
+++ b/src/HelloassoClient.php
@@ -12,12 +12,14 @@ use Helloasso\Models\Statistics\OrderDetail;
 use Helloasso\Models\Statistics\PaymentDetail;
 use Helloasso\Service\CheckoutIntentService;
 use Helloasso\Service\DirectoryService;
+use Helloasso\Service\PaymentService;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class HelloassoClient
 {
     public CheckoutIntentService $checkout;
+    public PaymentService $payment;
     public DirectoryService $directory;
 
     public function __construct(
@@ -27,6 +29,7 @@ class HelloassoClient
     ) {
         $this->checkout = new CheckoutIntentService($apiCaller, $organizationSlug);
         $this->directory = new DirectoryService();
+        $this->payment = new PaymentService($apiCaller, $organizationSlug);
     }
 
     /**

--- a/src/Http/ApiCaller.php
+++ b/src/Http/ApiCaller.php
@@ -43,10 +43,11 @@ class ApiCaller
      *
      * @return T
      */
-    public function get(string $url, string $responseClassType): HelloassoObject
+    public function get(string $url, string $responseClassType, array|HelloassoObject|null $request = null): HelloassoObject
     {
         $response = $this->httpClient->request(Request::METHOD_GET, $url, [
             'auth_bearer' => $this->tokenManager->getAccessToken(),
+            'body' => $request,
         ]);
 
         return $this->responseHandler->deserializeResponse($response, $responseClassType);

--- a/src/Http/ApiCaller.php
+++ b/src/Http/ApiCaller.php
@@ -22,16 +22,17 @@ class ApiCaller
     /**
      * @template T of HelloassoObject
      *
-     * @param class-string<T> $responseClassType
+     * @param class-string<T>      $responseClassType
+     * @param array<string, mixed> $options           HttpClient request options
      *
      * @return T
      */
-    public function post(string $url, array|HelloassoObject|null $body, string $responseClassType): HelloassoObject
+    public function post(string $url, array|HelloassoObject|null $body, string $responseClassType, ?array $options = []): HelloassoObject
     {
-        $response = $this->httpClient->request(Request::METHOD_POST, $url, [
+        $response = $this->httpClient->request(Request::METHOD_POST, $url, array_merge([
             'auth_bearer' => $this->tokenManager->getAccessToken(),
             'body' => $this->serializer->serialize($body, 'json'),
-        ]);
+        ], $options));
 
         return $this->responseHandler->deserializeResponse($response, $responseClassType);
     }
@@ -43,12 +44,11 @@ class ApiCaller
      *
      * @return T
      */
-    public function get(string $url, string $responseClassType, array|HelloassoObject|null $request = null): HelloassoObject
+    public function get(string $url, string $responseClassType, ?array $options = []): HelloassoObject
     {
-        $response = $this->httpClient->request(Request::METHOD_GET, $url, [
+        $response = $this->httpClient->request(Request::METHOD_GET, $url, array_merge([
             'auth_bearer' => $this->tokenManager->getAccessToken(),
-            'body' => $request,
-        ]);
+        ], $options));
 
         return $this->responseHandler->deserializeResponse($response, $responseClassType);
     }

--- a/src/Models/Common/Collection.php
+++ b/src/Models/Common/Collection.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helloasso\Models\Common;
+
+use Helloasso\Models\HelloassoObject;
+
+/**
+ * @template T of HelloassoObject
+ */
+abstract class Collection implements HelloassoObject
+{
+    /**
+     * @var T[]
+     */
+    protected array $data = [];
+
+    protected PaginationModel $pagination;
+
+    public function isEmpty(): bool
+    {
+        return 0 === \count($this->data);
+    }
+
+    /**
+     * @return T[]
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param T[] $data
+     */
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function getPagination(): PaginationModel
+    {
+        return $this->pagination;
+    }
+
+    public function setPagination(PaginationModel $pagination): self
+    {
+        $this->pagination = $pagination;
+
+        return $this;
+    }
+}

--- a/src/Models/Statistics/PaymentCollection.php
+++ b/src/Models/Statistics/PaymentCollection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helloasso\Models\Statistics;
+
+use Helloasso\Models\Common\Collection;
+
+/**
+ * @extends Collection<Payment>
+ */
+class PaymentCollection extends Collection
+{
+    /**
+     * Overriding the property with an @var annotation is needed for the
+     * serializer component until generics are not supported.
+     *
+     * @var Payment[]
+     */
+    protected array $data = [];
+}

--- a/src/Service/PaymentService.php
+++ b/src/Service/PaymentService.php
@@ -30,6 +30,18 @@ class PaymentService
      */
     public function all(array $params = []): PaymentCollection
     {
-        return $this->apiCaller->get("/v5/organizations/{$this->organizationSlug}/payments", PaymentCollection::class, $params);
+        return $this->apiCaller->get("/v5/organizations/{$this->organizationSlug}/payments", PaymentCollection::class, [
+            'query' => $params,
+        ]);
+    }
+
+    /**
+     * @throws HelloassoApiException
+     */
+    public function refund(int $id, array $params = []): Payment
+    {
+        return $this->apiCaller->post("/v5/payments/$id/refund", null, Payment::class, [
+            'query' => $params,
+        ]);
     }
 }

--- a/src/Service/PaymentService.php
+++ b/src/Service/PaymentService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helloasso\Service;
+
+use Helloasso\Exception\HelloassoApiException;
+use Helloasso\Http\ApiCaller;
+use Helloasso\Models\Statistics\Payment;
+use Helloasso\Models\Statistics\PaymentCollection;
+
+class PaymentService
+{
+    public function __construct(
+        private readonly ApiCaller $apiCaller,
+        private readonly string $organizationSlug,
+    ) {
+    }
+
+    /**
+     * @throws HelloassoApiException
+     */
+    public function retrieve(int $id): Payment
+    {
+        return $this->apiCaller->get("/v5/payments/$id", Payment::class);
+    }
+
+    /**
+     * @throws HelloassoApiException
+     */
+    public function all(array $params = []): PaymentCollection
+    {
+        return $this->apiCaller->get("/v5/organizations/{$this->organizationSlug}/payments", PaymentCollection::class, $params);
+    }
+}

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -14,7 +14,7 @@ abstract class FunctionalTestCase extends TestCase
     {
         $clientId = getenv('HELLOASSO_CLIENT_ID');
         $clientSecret = getenv('HELLOASSO_CLIENT_SECRET');
-        $organisationSlug = getenv('HELLOASSO_ORGANISATION') ? getenv('HELLOASSO_ORGANISATION_SLUG') : 'helloasso-php-sdk';
+        $organisationSlug = false !== getenv('HELLOASSO_ORGANISATION') ? getenv('HELLOASSO_ORGANISATION') : 'helloasso-php-sdk';
 
         if (empty($clientId) || empty($clientSecret)) {
             $this->markTestSkipped();

--- a/tests/Functional/Service/PaymentServiceTest.php
+++ b/tests/Functional/Service/PaymentServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Helloasso\Tests\Functional\Service;
 
+use Helloasso\Enums\PaymentState;
 use Helloasso\Models\Statistics\Payment;
 use Helloasso\Models\Statistics\PaymentCollection;
 use Helloasso\Tests\Functional\FunctionalTestCase;
@@ -16,7 +17,7 @@ final class PaymentServiceTest extends FunctionalTestCase
         $this->assertInstanceOf(PaymentCollection::class, $paymentCollection);
 
         if ($paymentCollection->isEmpty()) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('No payment fund in collection');
         }
 
         $paymentId = $paymentCollection->getData()[0]->getId();
@@ -24,5 +25,27 @@ final class PaymentServiceTest extends FunctionalTestCase
         $payment = $this->getClient()->payment->retrieve($paymentId);
         $this->assertInstanceOf(Payment::class, $payment);
         $this->assertSame($paymentId, $payment->getId());
+
+        $this->markTestSkipped('Refund test is disable for now as it requires special permissions, even on sandbox environment.');
+
+        /* @phpstan-ignore-next-line Ignored due do skipped test */
+        if (null === $refundablePayment = $this->getRefundablePayment($paymentCollection)) {
+            $this->markTestSkipped('No refundable payment found in collection');
+        }
+
+        $payment = $this->getClient()->payment->refund($refundablePayment->getId(), ['comment' => 'Refunded from functional test']);
+        $this->assertSame(PaymentState::Refunded, $payment->getState());
+    }
+
+    /* @phpstan-ignore-next-line Ignored due do skipped test */
+    private function getRefundablePayment(PaymentCollection $paymentCollection): ?Payment
+    {
+        foreach ($paymentCollection->getData() as $payment) {
+            if (PaymentState::Authorized === $payment->getState()) {
+                return $payment;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Functional/Service/PaymentServiceTest.php
+++ b/tests/Functional/Service/PaymentServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helloasso\Tests\Functional\Service;
+
+use Helloasso\Models\Statistics\Payment;
+use Helloasso\Models\Statistics\PaymentCollection;
+use Helloasso\Tests\Functional\FunctionalTestCase;
+
+final class PaymentServiceTest extends FunctionalTestCase
+{
+    public function testAll(): void
+    {
+        $paymentCollection = $this->getClient()->payment->all();
+        $this->assertInstanceOf(PaymentCollection::class, $paymentCollection);
+
+        if ($paymentCollection->isEmpty()) {
+            $this->markTestSkipped();
+        }
+
+        $paymentId = $paymentCollection->getData()[0]->getId();
+
+        $payment = $this->getClient()->payment->retrieve($paymentId);
+        $this->assertInstanceOf(Payment::class, $payment);
+        $this->assertSame($paymentId, $payment->getId());
+    }
+}


### PR DESCRIPTION
Ajout de nouveau endpoint supportés (dont j'ai besoin héhé).

La méthode `refund` n'est pas testée car elle nécessite des permissions particulières dont l'asso de test n'est pas (encore ! :crossed_fingers: ) dotée.

Je suis en discussion avec des personnes d'helloasso pour que la fonctionnalité de remboursement soit activée sur l'asso de test, espérons que ma demande soit acceptée prochainement. :)