### PR TITLE
Add checkoutIntentId property to Order object

### DIFF
--- a/src/Models/Statistics/Order.php
+++ b/src/Models/Statistics/Order.php
@@ -30,6 +30,8 @@ class Order implements HelloassoObject
     private string $organizationSlug;
     private MetaModel $meta;
 
+    private ?int $checkoutIntentId = null;
+
     public function getPayer(): PayerLight
     {
         return $this->payer;
@@ -170,6 +172,18 @@ class Order implements HelloassoObject
     public function setMeta(MetaModel $meta): self
     {
         $this->meta = $meta;
+
+        return $this;
+    }
+
+    public function getCheckoutIntentId(): ?int
+    {
+        return $this->checkoutIntentId;
+    }
+
+    public function setCheckoutIntentId(?int $checkoutIntentId): self
+    {
+        $this->checkoutIntentId = $checkoutIntentId;
 
         return $this;
     }

--- a/src/Models/Statistics/OrderLight.php
+++ b/src/Models/Statistics/OrderLight.php
@@ -20,6 +20,8 @@ class OrderLight implements HelloassoObject
     private FormType $formType;
     private MetaModel $meta;
 
+    private ?int $checkoutIntentId = null;
+
     public function getId(): int
     {
         return $this->id;
@@ -100,6 +102,18 @@ class OrderLight implements HelloassoObject
     public function setMeta(MetaModel $meta): self
     {
         $this->meta = $meta;
+
+        return $this;
+    }
+
+    public function getCheckoutIntentId(): ?int
+    {
+        return $this->checkoutIntentId;
+    }
+
+    public function setCheckoutIntentId(?int $checkoutIntentId): self
+    {
+        $this->checkoutIntentId = $checkoutIntentId;
 
         return $this;
     }


### PR DESCRIPTION
This attribute is present:
- in the OrderLight returned by the payment_retrieve response (https://dev.helloasso.com/reference/get_payments-paymentid) 
- in the Order object returned by the order_retrieve response (https://dev.helloasso.com/reference/get_items-itemid)